### PR TITLE
Fix capitalization of build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ git clone https://github.com/Nikknakk/Brightwork-Theme
 
 3. Open the ```_config.scss``` and choose your primary color and shade, or any other changes you would like. Build the theme and install with: 
 ```
-Meson Build
+meson build
 cd build
 sudo ninja render install 
 ```


### PR DESCRIPTION
Otherwise the meson command will throw an error if copy-and-pasted.