### PR TITLE
Make app switcher selection confirm to user corner preference

### DIFF
--- a/common/gtk/_sass/apps/_budgie.scss
+++ b/common/gtk/_sass/apps/_budgie.scss
@@ -373,7 +373,7 @@
     :selected image {
     padding:4px;
     background-color:$ps_color;
-    border-radius:40%;
+    border-radius: $corner;
     }
 
     .drop-shadow {


### PR DESCRIPTION
This makes more rectangular configs keep their rectangular look even in this case, while keeping the rounded look of the default and other round configs.

Default:
![Round](https://user-images.githubusercontent.com/6317346/59952319-fee7c080-947b-11e9-962e-273566ebbae6.png)


Rectangular:
![Rect](https://user-images.githubusercontent.com/6317346/59952320-0018ed80-947c-11e9-9b2d-a8932e8ebdc0.png)
